### PR TITLE
Allow hyphen in DDT

### DIFF
--- a/src/Dynamic_Data_Tag.php
+++ b/src/Dynamic_Data_Tag.php
@@ -175,7 +175,7 @@ class Dynamic_Data_Tag
      */
     private function parse_tag(string $content): array
     {
-        $pattern = "/{" .$this->tag. "(?::(?<filters>[0-9a-zA-Z_]+(?::[0-9a-zA-Z_]+)*))?}/";
+        $pattern = "/{" .$this->tag. "(?::(?<filters>[0-9a-zA-Z_-]+(?::[0-9a-zA-Z_-]+)*))?}/";
         $pattern = apply_filters("juvo/dynamic_data_tag/parse_tag", $pattern, $this->tag);
         $pattern = apply_filters("juvo/dynamic_data_tag/parse_tag/$this->tag", $pattern, $this->tag);
 


### PR DESCRIPTION
The library doesn't allow hyphens used in the DDT declaration. Strings like "foo-bar" won't be recognized.